### PR TITLE
[DL-5330] Add worship types concept scheme

### DIFF
--- a/lib/enricher.js
+++ b/lib/enricher.js
@@ -7,6 +7,7 @@ import fs from 'fs-extra';
 const META_FILE_PATH = './share/meta.ttl';
 const ADMINISTRATIVE_UNITES = 'http://lblod.data.gift/concept-schemes/7e2b965e-c824-474f-b5d5-b1c115740083';
 const CHART_OF_ACCOUNTS = 'http://lblod.data.gift/concept-schemes/b65b15ba-6755-4cd2-bd07-2c2cf3c0e4d3';
+const WORSHIP_TYPES = 'http://lblod.data.gift/concept-schemes/5be1fce008d73105d9bc6de9e488b0b9';
 
 const CONCEPT_SCHEMES = [
   'http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode', // Administrative Unit Classifications
@@ -15,7 +16,8 @@ const CONCEPT_SCHEMES = [
   'http://lblod.data.gift/concept-schemes/c93ccd41-aee7-488f-86d3-038de890d05a', // Regulation Types
   CHART_OF_ACCOUNTS,
   'http://lblod.data.gift/concept-schemes/372797ff-917c-4572-925f-f09cc30932e6', // Provinces
-  'http://lblod.data.gift/concept-schemes/3037c4f4-1c63-43ac-bfc4-b41d098b15a6' // Tax Types
+  'http://lblod.data.gift/concept-schemes/3037c4f4-1c63-43ac-bfc4-b41d098b15a6', // Tax Types
+  WORSHIP_TYPES
 ];
 
 export async function getMetaData() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toezicht-search-query-management-service",
-  "version": "0.3.7-rc.1",
+  "version": "0.3.6",
   "description": "Service that provides management of search-queries.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toezicht-search-query-management-service",
-  "version": "0.3.6",
+  "version": "0.3.7-rc.1",
   "description": "Service that provides management of search-queries.",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.2.0",


### PR DESCRIPTION
# Description
DL-5330

This PR adds a new concept scheme for worship types, it's used to replace current filter `Type bestuursorgaan` filter for `Type eredienst` so users can look for recognized worship types when they're already filtering on `Type bestuur` leaving them 6 options to pick from _(Anglicaanse, Islamitische, Israëlitische, Orthodox, Protestantse of Rooms-Katholiek)_.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- [frontend-worship-decisions](https://github.com/lblod/frontend-worship-decisions)
- mu-cl-resource
- [toezicht-search-query-management](https://github.com/lblod/toezicht-search-query-management-service)

# How to test (From Loket app)

1. drc up -d 
2. Make sure the seach-query-management and frontend services have been pulled.
3. Log as ABB.
4. Apply type bestuur filter then type eredienst based on the 6 options.
5. It should show results.

**See Examples here**

![Screenshot 2024-06-10 at 18-04-26 Erediensten Toezichtsdatabank](https://github.com/lblod/app-worship-decisions-database/assets/38471754/3326c9c4-1098-43ff-9521-04a0c32e81bf)

![Screenshot 2024-06-10 at 18-04-47 Erediensten Toezichtsdatabank](https://github.com/lblod/app-worship-decisions-database/assets/38471754/f0aa0341-9ba3-45b5-be6c-e51443a3472c)



# What to check

- Typos 

# Links to other PR's

- https://github.com/lblod/frontend-worship-decisions/pull/23
- https://github.com/lblod/app-worship-decisions-database/pull/81

# Notes

- Make proper release